### PR TITLE
General readme and bash script cleanup

### DIFF
--- a/Bash/azure-rg-deploy.sh
+++ b/Bash/azure-rg-deploy.sh
@@ -22,11 +22,17 @@ done
 templateName="$( basename "${templateFile%.*}" )"
 templateDirectory="$( dirname "$templateFile")"
 
-parametersFile=${parametersFile:-${templateDirectory}/${templateName}".parameters.json"}
-resourceGroupName=${resourceGroupName:-${templateName}}
+if [[ -z $parametersFile ]]
+then
+    parametersFile=${parametersFile:-${templateDirectory}/${templateName}".parameters.json"}
+fi
 
-artifactsSourceFolder1="/Artifacts"
-artifactsSourceFolder=$templateDirectory$artifactsSourceFolder1
+if [[ -z $resourceGroupName ]]
+then
+    resourceGroupName=${resourceGroupName:-${templateName}}
+fi
+
+artifactsSourceFolder=$templateDirectory"/Artifacts"
 
 parameterJson=$( cat "$parametersFile" | jq '.parameters' )
 
@@ -34,7 +40,7 @@ azure config mode arm
 
 # When $artifactsSourceFolder contains files, they will be staged in a storage account.
 artifactsCount=$( ls "$artifactsSourceFolder" 2>/dev/null | wc -l )
-if [ ! -z "$artifactsSourceFolder" ] && [ -r "$artifactsSourceFolder" ] && [ $artifactsCount -gt 0 ]
+if [[ ! -z "$artifactsSourceFolder" ]] && [[ -r "$artifactsSourceFolder" ]] && [[ $artifactsCount -gt 0 ]]
 then
     subscriptionId=$( azure account show --json | jq -r '.[0].id' )
     artifactsResourceGroupName="ARM_Deploy_Staging"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See [Authoring Azure Resource Manager Templates](https://azure.microsoft.com/en-
 
 #### OSX/Linux
 * Open a terminal window and run `azure login` to login.
-* If the account has access to multiple subscriptions, use `azure account set <subscription name>` to switch to the one you want to use.
+* If the account has access to multiple subscriptions, use `azure account set <subscription name or id>` to switch to the one you want to use.
 * Update the values in the **Bash/LinuxVirtualMachineSample.parameters.json** file.
 * Run the bash Script: `Bash/azure-rg-deploy.sh -f Bash/LinuxVirtualMachineSample.json -l <Azure Region>`.
 


### PR DESCRIPTION
Fixing azure-rg-deploy.sh to use the provided parametersFile and resourceGroupName parameters if they are provided. Also removes the "artifactsSourceFolder1" variable that was only used once.