### PR TITLE
Schema $ + Variable and Parameter Snippits

### DIFF
--- a/VSCode/armsnippets.json
+++ b/VSCode/armsnippets.json
@@ -15,14 +15,14 @@
     ],
     "description": "Skeleton ARM Template"
 },
-"Azure Resource Manager (ARM) Variable": {
+"Variable": {
     "prefix": "arm-variable",
     "body": [
         "\"${1:variableName}\": \"${2:variableValue}\""
     ],
     "description": "ARM Variable"
 },
-"Azure Resource Manager (ARM) Parameter": {
+"Parameter": {
     "prefix": "arm-parameter",
     "body": [
         "\"${1:parameterName}\": {",

--- a/VSCode/armsnippets.json
+++ b/VSCode/armsnippets.json
@@ -5,7 +5,7 @@
     "prefix": "arm!",
     "body": [
         "{",
-        "    \"$schema\": \"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",",
+        "    \"$$schema\": \"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",",
         "    \"contentVersion\": \"1.0.0.0\",",
         "    \"parameters\": {},",
         "    \"variables\": {},",

--- a/VSCode/armsnippets.json
+++ b/VSCode/armsnippets.json
@@ -15,6 +15,25 @@
     ],
     "description": "Skeleton ARM Template"
 },
+"Azure Resource Manager (ARM) Variable": {
+    "prefix": "arm-variable",
+    "body": [
+        "\"${1:variableName}\": \"${2:variableValue}\""
+    ],
+    "description": "ARM Variable"
+},
+"Azure Resource Manager (ARM) Parameter": {
+    "prefix": "arm-parameter",
+    "body": [
+        "\"${1:parameterName}\": {",
+        "   \"type\": \"${2:string}\",",
+        "   \"metadata\": {",
+        "        \"description\": \"${3:}\"",
+        "    }",
+        "}"
+    ],
+    "description": "ARM Parameter"
+},
 "App Service Plan (Server Farm)": {
     "prefix": "arm-plan",
     "body": [


### PR DESCRIPTION
The "Skeleton ARM Template" snippet was not showing the $ sign when used. Added extra $ to make it show.

Also added snippet support for ARM variables and ARM parameters.