### PR TITLE
Update ASP API version to match SKU definition

### DIFF
--- a/VSCode/armsnippets.json
+++ b/VSCode/armsnippets.json
@@ -58,7 +58,7 @@
     "prefix": "arm-plan",
     "body": [
         "{",
-        "    \"apiVersion\": \"2014-06-01\",",
+        "    \"apiVersion\": \"2016-09-01\",",
         "    \"name\": \"${AppServicePlan1}\",",
         "    \"type\": \"Microsoft.Web/serverfarms\",",
         "    \"location\": \"[resourceGroup().location]\",",


### PR DESCRIPTION
For API version [2014-06-01](https://github.com/Azure/azure-resource-manager-schemas/blob/master/schemas/2014-06-01/Microsoft.Web.json), the `sku` property of the `Microsoft.Web/serverfarms` resource is defined as an enumerated value, not an object, which causes the value to be ignored when deploying the template.

Updating the API version to [2016-09-01](https://github.com/Azure/azure-resource-manager-schemas/blob/master/schemas/2016-09-01/Microsoft.Web.json), where it is correctly defined as an object of type `SkuDescription`.