### PR TITLE
Feature/add snippet automation module (issue #41)

### DIFF
--- a/VSCode/armsnippets.json
+++ b/VSCode/armsnippets.json
@@ -490,6 +490,23 @@
     ],
     "description": "Automation Variable"
 },
+"Automation Module":{
+    "prefix": "arm-automation-module",
+    "body": [
+        "{",
+        "    \"name\": \"[concat('${2:automationAccount1}', '/${1:automationVariable1}')]\",",
+        "    \"type\": \"Microsoft.Automation/automationAccounts/modules\",",
+        "    \"apiVersion\": \"2015-10-31\",",
+        "    \"dependsOn\": [",
+        "        \"[resourceId('Microsoft.Automation/automationAccounts', '${2:automationAccount1}')]\"",
+        "    ],",
+        "    \"properties\": {",
+        "        \"contentLink\": \"{}\"",
+        "    }",
+        "}"
+    ],
+    "description": "Automation Module"
+},
 "Availability Set": {
     "prefix": "arm-availability-set",
     "body": [


### PR DESCRIPTION
I added the snippets for automation module

I used the same naming convention used when you extract the ARM template from the portal. This will concatenate the automation name with the name of the "module"

**Ex:** 
To add the module `Az.ResourceGraph` the resulting line in the ARM template will be:

`"name": "[concat('automationAccount, '/Az.ResourceGraph')]"`

> Note: Is PR assumes the PR 40 is already merged.
