### PR TITLE
Add snippet for APIM

### DIFF
--- a/VSCode/armsnippets.json
+++ b/VSCode/armsnippets.json
@@ -110,6 +110,39 @@
     ],
     "description": "Nested Deployment"
 },
+"API Management": {
+    "prefix": "arm-apim",
+    "body": [
+        "{",
+        "    \"name\": \"${1:apiManagement1}\",",
+        "    \"type\": \"Microsoft.ApiManagement/service\",",
+        "    \"apiVersion\": \"2019-01-01\",",
+        "    \"location\": \"[resourceGroup().location]\",",
+        "    \"tags\": {",
+        "        \"displayName\": \"${1:apiManagement1}\"",
+        "    },",
+        "    \"sku\": {",
+        "        \"name\": \"Developer\",",
+        "        \"capacity\": 1",
+        "    },",
+        "    \"properties\": {",
+        "        \"notificationSenderEmail\": \"${2:notification@example.net}\",",
+        "        \"hostnameConfigurations\": [",
+        "            {",
+        "                \"type\": \"${3:proxy}\",",
+        "                \"hostName\": \"${4:myHostname.example.net}\"",
+        "            }",
+        "        ],",
+        "        \"virtualNetworkConfiguration\": {",
+        "            \"subnetResourceId\": \"[resourceId('Microsoft.Network/virtualNetworks/subnets', ${5:'apim-vnet'}, ${6:'apim-subnet'})]\"",
+        "        },",
+        "        \"virtualNetworkType\": \"${7:None}\",",
+        "        \"publisherEmail\": \"${8:name@example.net}\",",
+        "        \"publisherName\": \"${9:J. Doe}\"",
+        "    }",
+        "}"
+    ]
+},
 "App Service Plan (Server Farm)": {
     "prefix": "arm-plan",
     "body": [


### PR DESCRIPTION
Add snippet for APIM, settled for the [latest API documented](https://docs.microsoft.com/en-us/azure/templates/microsoft.apimanagement/2019-01-01/service).

Opted to add the fields that most people will want to customise on initial set-up. Configuring certificates adds much more complexity due to KeyVault.

But I'm totally open to amending to providing *all* fields and add initial data for them. So please let me know what is typical, @philon-msft.